### PR TITLE
feat: wire freebie_planner to canonical funnel slugs for all 15 topics

### DIFF
--- a/phoenix_v4/planning/freebie_planner.py
+++ b/phoenix_v4/planning/freebie_planner.py
@@ -218,6 +218,23 @@ def plan_freebies(
     persona_id = _get(book_spec, "persona_id") or ""
     engine = _get(arc, "engine") or ""
 
+    # ── Funnel map lookup (config/funnel/freebie_to_book_map.yaml) ──────────────
+    # For canonical topics, use the real landing-page slug from the funnel map
+    # rather than the algorithmic {topic}-{persona}-{freebie_part} slug.
+    # This ensures book CTAs point to real freebie landing pages that exist.
+    # Falls through to algorithmic generation only if topic not in map.
+    _funnel_map = _load_yaml(REPO_ROOT / "config" / "funnel" / "freebie_to_book_map.yaml")
+    _funnel_topic = (_funnel_map.get("topics") or {}).get(topic_id) if topic_id else None
+    if _funnel_topic:
+        _freebie_cfg = _funnel_topic.get("freebie") or {}
+        _canonical_slug = _freebie_cfg.get("slug") or ""
+        if _canonical_slug:
+            _freebie_registry_id = _freebie_cfg.get("freebie_registry_id") or _canonical_slug
+            _cta_cfg = _funnel_topic.get("social_cta") or {}
+            _cta_template_id = _cta_cfg.get("cta_template_id") or "tool_forward"
+            return ([_freebie_registry_id], _cta_template_id, _canonical_slug)
+    # ── End funnel map lookup ────────────────────────────────────────────────────
+
     duration_min = _book_duration_minutes(format_plan)
     duration_class = _duration_class(duration_min)
     has_exercise = _has_exercise_slot(compiled)


### PR DESCRIPTION
## Problem

Every book rendered by the pipeline had a broken freebie CTA. The `freebie_planner.py` was generating algorithmic slugs like `anxiety-millennial-women-professionals-accountability-partner-v1` — none of which match any real landing page. The 15 real freebie landing pages (built in PRs #332/#333) live at slugs like `anxiety-nervous-system-reset`.

## Fix

17 lines added to `phoenix_v4/planning/freebie_planner.py`.

`plan_freebies()` now checks `config/funnel/freebie_to_book_map.yaml` first. If the topic is one of the 15 canonical funnel topics, it returns the canonical slug immediately. Non-canonical topics fall through to the existing algorithmic generator unchanged.

**Before:** `anxiety` → `anxiety-millennial-women-professionals-accountability-partner-v1` (broken URL)
**After:** `anxiety` → `anxiety-nervous-system-reset` (real landing page at brand-admin-onboarding.pages.dev/free/anxiety-nervous-system-reset/)

## Test results

```
PASS anxiety          → 'anxiety-nervous-system-reset'
PASS burnout          → 'burnout-energy-audit'
PASS grief            → 'grief-letter-template'
PASS sleep_anxiety    → 'sleep-anxiety-wind-down'
PASS boundaries       → 'boundaries-script-kit'
PASS unknown_xyz      → algorithmic fallback (no regression)
```

## Subsystems touched
core_pipeline (freebie_planner only — 1 file, 17 lines)

## Test plan
- [x] 5 canonical topics return correct slug
- [x] Unknown topic falls back to algorithmic generator
- [x] book_renderer.py CTA URL unchanged (already uses plan["freebie_slug"])
- [ ] Run full pipeline on anxiety book, verify CTA in rendered output

PROJECT_ID: proj_state_convergence_20260328

🤖 Generated with [Claude Code](https://claude.com/claude-code)