### PR TITLE
docs(coord): funnel pipeline merge closeout receipt

### DIFF
--- a/artifacts/coordination/FUNNEL_PIPELINE_MERGE_CLOSEOUT_2026_04_10.md
+++ b/artifacts/coordination/FUNNEL_PIPELINE_MERGE_CLOSEOUT_2026_04_10.md
@@ -1,0 +1,38 @@
+# Funnel pipeline merge closeout — 2026-04-10
+
+**Project:** `proj_state_convergence_20260328`  
+**Workstream:** `ws_full_funnel_system_20260410` (see `ACTIVE_WORKSTREAMS.tsv`)
+
+## Verified repo state
+
+| Item | Value |
+|------|--------|
+| `origin/main` tip | `c3d7c4c8a42fba73e6a97d865f52c4ae24016bbe` |
+| PR #350 (registry quality gates in `scripts/run_pipeline.py`) merged at | `e0412c7006e4138ff12d4690e53be24a85de8ac9` |
+| PR #352 (canonical funnel slugs in `phoenix_v4/planning/freebie_planner.py`) merged at | `a4cad9203eda2789255db57eb85e4888d6dfd7c6` |
+| PR #355 (coordination bookkeeping only) merged at | `c3d7c4c8a42fba73e6a97d865f52c4ae24016bbe` |
+
+**Summary:** PRs **#350** and **#352** carried the funnel integration work (registry-mode quality gates; planner → `config/funnel/freebie_to_book_map.yaml` slugs for all 15 canonical topics). **PR #355** changed **only** `artifacts/coordination/ACTIVE_WORKSTREAMS.tsv` to mark the workstream complete and record merge evidence.
+
+PR #352 used **admin merge** because the required check **Workers Builds: pearl-prime** failed while Core tests, Release gates, EI V2 gates, and governance were green (see `docs/GITHUB_OPERATIONS_FRAMEWORK.md`).
+
+## CLOSEOUT_RECEIPT (wording for handoffs)
+
+```
+CLOSEOUT_RECEIPT
+AGENT:          Pearl_GitHub + Pearl_Dev + Pearl_PM
+TASK:           Funnel pipeline integration (#350, #352) + coordination closeout (#355)
+COMMIT_SHA:     c3d7c4c8a42fba73e6a97d865f52c4ae24016bbe
+FILES_WRITTEN:  artifacts/coordination/ACTIVE_WORKSTREAMS.tsv (via PR #355 only)
+FILES_READ:     docs/SESSION_UNITY_PROTOCOL.md; docs/FULL_FUNNEL_PLAN.md; funnel/freebie configs; run_pipeline; freebie_planner; book_renderer
+STATUS:         completed
+HANDOFF_TO:     none
+NEXT_ACTION:    manual/off-repo only — GHL activation, GA4 measurement ID replacement, real store URLs
+```
+
+**Note:** `FILES_WRITTEN` here means files changed in the **closeout PR** (#355). Code for #350 and #352 landed in their respective merges.
+
+## Evidence
+
+- Row: `ws_full_funnel_system_20260410` in `artifacts/coordination/ACTIVE_WORKSTREAMS.tsv`
+- PR links: [350](https://github.com/Ahjan108/phoenix_omega_v4.8/pull/350), [352](https://github.com/Ahjan108/phoenix_omega_v4.8/pull/352), [355](https://github.com/Ahjan108/phoenix_omega_v4.8/pull/355)


### PR DESCRIPTION
Adds artifacts/coordination/FUNNEL_PIPELINE_MERGE_CLOSEOUT_2026_04_10.md — verified SHAs for main and PRs #350/#352/#355, refined CLOSEOUT_RECEIPT wording (FILES_WRITTEN = PR #355 scope; NEXT_ACTION = manual/off-repo only). Code changes were merged earlier; this PR is documentation only.

Made with [Cursor](https://cursor.com)