### PR TITLE
fix(pipeline): remove dedup word-floor retention bypass (P0.4)

### DIFF
--- a/phoenix_v4/rendering/book_renderer.py
+++ b/phoenix_v4/rendering/book_renderer.py
@@ -333,9 +333,13 @@ def _dedup_repeated_blocks(
     Paragraphs are split on blank-line runs. Paragraphs with fewer than ``min_words`` words
     are always kept and do not participate in deduplication (short transitions may repeat).
 
-    When ``word_floor`` > 0 (from the runtime format's minimum word target), if deduplication
-    would shrink the text below that floor, the pre-dedup string is kept so thin registry
-    builds do not lose counted repetition that the word gate still expects.
+    Deduplication ALWAYS runs. The ``word_floor`` parameter is retained as a
+    diagnostic signal: when post-dedup word count falls below the runtime
+    format's floor, a structured warning is emitted so the operator can see
+    the repetition was masking insufficient unique content. The bypass that
+    previously kept pre-dedup text below the floor is removed — preserving
+    duplicates to hit a length target produces fake-length books and is the
+    documented dedup-floor regression in the bestseller drift report.
     """
     if not (text or "").strip():
         return text
@@ -362,15 +366,24 @@ def _dedup_repeated_blocks(
 
     deduped = "\n\n".join(kept)
     post_wc = len(deduped.split())
+    unique_ratio = (post_wc / pre_wc) if pre_wc else 1.0
     if word_floor > 0 and post_wc < word_floor:
         logger.warning(
-            "Repeated-block dedup would shrink text from %s to %s words (below floor %s); "
-            "keeping pre-dedup text.",
+            "dedup_below_floor nominal=%s deduped=%s floor=%s unique_ratio=%.3f — "
+            "deduped text returned (no longer retains duplicates to hit floor).",
             pre_wc,
             post_wc,
             word_floor,
+            unique_ratio,
         )
-        return text
+    elif unique_ratio < 0.7 and pre_wc >= 200:
+        logger.warning(
+            "dedup_low_unique_ratio nominal=%s deduped=%s unique_ratio=%.3f — "
+            "more than 30%% of text was repeated long-paragraph duplication.",
+            pre_wc,
+            post_wc,
+            unique_ratio,
+        )
     return deduped
 
 

--- a/tests/test_book_renderer.py
+++ b/tests/test_book_renderer.py
@@ -402,7 +402,11 @@ def test_dedup_four_count_breath_section_deduplicated() -> None:
     assert out.count("Inhale for four counts") == 1
 
 
-def test_dedup_repeated_blocks_keeps_pre_dedup_when_below_word_floor() -> None:
+def test_dedup_repeated_blocks_always_runs_regardless_of_word_floor(caplog) -> None:
+    """Dedup always returns the deduped text. The word_floor bypass that previously
+    retained duplicates to hit a length target is removed (fake-length regression)."""
+    import logging
+
     from phoenix_v4.rendering.book_renderer import _dedup_repeated_blocks
 
     p = (
@@ -413,21 +417,31 @@ def test_dedup_repeated_blocks_keeps_pre_dedup_when_below_word_floor() -> None:
     text = f"{p}\n\n{p}\n"
     shrunk = _dedup_repeated_blocks(text, word_floor=0)
     assert shrunk.count("This paragraph is long enough") == 1
-    kept = _dedup_repeated_blocks(text, word_floor=5000)
-    assert kept.count("This paragraph is long enough") == 2
+    with caplog.at_level(logging.WARNING):
+        deduped_below_floor = _dedup_repeated_blocks(text, word_floor=5000)
+    # Dedup runs regardless of floor — duplicates are removed.
+    assert deduped_below_floor.count("This paragraph is long enough") == 1
+    # A diagnostic warning is emitted when post-dedup text falls below the runtime floor.
+    assert any("dedup_below_floor" in r.message for r in caplog.records)
 
 
-def test_clean_for_delivery_dedup_respects_runtime_word_floor() -> None:
+def test_clean_for_delivery_dedup_always_removes_duplicates() -> None:
+    """clean_for_delivery dedup always removes long-paragraph duplicates regardless
+    of runtime word floor. The previous bypass (keep duplicates when post-dedup
+    falls below runtime word floor) is removed — duplicates were inflating
+    nominal length while the user saw fake-length books.
+    """
     long_para = (
         "This duplicate long paragraph is written for runtime word floor testing "
         "with more than twenty words so dedup would normally remove the second copy "
-        "but the format floor requires keeping pre-dedup word count for thin books."
+        "and the format floor no longer keeps pre-dedup duplicates for thin books."
     )
     raw = f"{long_para}\n\n{long_para}\n"
     out_no_plan = clean_for_delivery(raw)
     assert out_no_plan.count("duplicate long paragraph") == 1
     out_with_plan = clean_for_delivery(raw, plan={"runtime_format_id": "short_book_30"})
-    assert out_with_plan.count("duplicate long paragraph") == 2
+    # Dedup runs even under short_book_30 floor — duplicates are gone.
+    assert out_with_plan.count("duplicate long paragraph") == 1
 
 
 def test_clean_for_delivery_strips_concatenated_spine_hook_lines() -> None:


### PR DESCRIPTION
## Summary
- Removes the `_dedup_repeated_blocks` bypass that retained pre-dedup text when post-dedup word count would fall below the runtime floor.
- Per the bestseller drift analysis, this bypass was preserving 47–69% duplicate text to hit nominal length targets, producing fake-length books.
- Dedup now always runs. The `word_floor` parameter is retained as a diagnostic signal — emits structured `dedup_below_floor` and `dedup_low_unique_ratio` warnings.

## Why
- forensic regression audit (`cursor_forensic_regression_audit_of_boo.md`) named this as a primary mechanism for the perceived quality drop.
- piper_prompter chat spec explicitly ordered the bypass removed: "REMOVE the dedup word-count bypass."
- Documented as Disconnection 3 in `artifacts/analysis/peak_quality_reconstruction.md` and as P0.4 in `artifacts/analysis/shortest_path_to_bestseller.md`.

## Test plan
- [x] `tests/test_book_renderer.py::test_dedup_repeated_blocks_always_runs_regardless_of_word_floor` — dedup runs and `dedup_below_floor` warning is logged.
- [x] `tests/test_book_renderer.py::test_clean_for_delivery_dedup_always_removes_duplicates` — duplicates removed even under `short_book_30` floor.
- [x] All 12 dedup/clean_for_delivery tests pass.
- [ ] Manual verification on flagship anxiety ladder happens after Sprint 1 + 2 land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)