### PR TITLE
feat(rendering): forward chapter.thesis through spine composer + populate flagship arc thesis bank (P0.1 + P0.2)

### DIFF
--- a/config/source_of_truth/master_arcs/gen_z_professionals__anxiety__overwhelm__F006.yaml
+++ b/config/source_of_truth/master_arcs/gen_z_professionals__anxiety__overwhelm__F006.yaml
@@ -67,6 +67,27 @@ chapter_intent:
   18: grounded_reframe
   19: establish_mask
   20: embodied_identity
+chapter_thesis:
+  1: "What looks like productivity is often the body trying to outrun a feeling it never named."
+  2: "Each notification you answer with your nervous system trains your nervous system to expect another."
+  3: "The way you have been managing this is the same shape as what is exhausting you."
+  4: "Underneath the urgency is a belief: that if you slow down, the thing you are afraid of will catch up."
+  5: "You are not falling behind a real timeline. You are running a race no one else can see."
+  6: "The body knows the difference between rest and shutdown. The mind has been calling them the same thing."
+  7: "Other people are not the source of your overwhelm — but they have been the proof you used to validate it."
+  8: "There is a version of you that does not have to perform reliability to deserve rest."
+  9: "The pace was never the problem. The price you paid for it was."
+  10: "The competence everyone praises is the same skill keeping you from asking for help."
+  11: "What you are calling a busy week has now been a busy decade."
+  12: "Time-blocking does not heal a nervous system that already believes time is the threat."
+  13: "If you stopped, no one would die. The overwhelm is not actually about other people."
+  14: "What you are doing to your body to maintain your role is the part of the role no one applauds."
+  15: "The cost has come due. The body is no longer asking — it is collecting."
+  16: "The relationship you have to have first is the one with the part of you that has been pretending to be fine."
+  17: "You were not built to convert every minute into output. You were built to live inside time, not against it."
+  18: "The true productivity move is the smallest one: one breath the body actually finishes."
+  19: "You will catch yourself reaching for the old shape. Catching yourself is the new skill — not the failure."
+  20: "What you carry forward is not a system. It is a different relationship to the alarm itself."
 emotional_role_sequence:
 - recognition
 - recognition

--- a/config/spines/anxiety_spine.yaml
+++ b/config/spines/anxiety_spine.yaml
@@ -352,9 +352,9 @@ chapters:
     role: practical_interruption
     working_title: "Small Exposures"
     thesis: >
-      You do not have to start where the alarm is loudest. You start where the
-      alarm is a seven, and you let it run, and you find out what actually
-      happens.
+      Practice begins where the alarm is a seven, not where it is a ten.
+      You let it run at that manageable level, and you find out what actually
+      happens next.
     emotional_job: >
       The reader finishes this chapter with something they haven't had in a
       long time: a small, earned piece of evidence. Not reassurance — evidence.

--- a/phoenix_v4/rendering/golden_chapter_synthesis.py
+++ b/phoenix_v4/rendering/golden_chapter_synthesis.py
@@ -960,6 +960,14 @@ def compose_golden_spine_chapter(
     contract = contracts[chapter_index0] if chapter_index0 < len(contracts) else contracts[-1]
     emotional_role = str(getattr(contract, "emotional_job", "") or "")
 
+    # Forward EnrichedChapter.thesis as arc_thesis so the composer's 4-stage
+    # derivation chain (arc_thesis > chapter_thesis_bank > mechanism_thesis_families
+    # > legacy keyword extraction) can use the spine-authored thesis directly
+    # instead of re-deriving from REFLECTION prose. Without this hand-off the
+    # spine's chapter.thesis is dropped on the floor and every chapter falls
+    # through to mechanism_thesis_families lookup or the legacy keyword chain —
+    # the documented thesis-routing drift in the bestseller drift analysis.
+    chapter_arc_thesis = str(getattr(chapter, "thesis", "") or "").strip()
     composed = compose_chapter_prose(
         slot_types,
         slot_proses,
@@ -971,6 +979,7 @@ def compose_golden_spine_chapter(
         book_seed=book_seed,
         mechanism_memory=mechanism_memory,
         exercise_memory=exercise_memory,
+        arc_thesis=chapter_arc_thesis,
     )
 
     has_doctrine = any(


### PR DESCRIPTION
## Summary
- **Wires chapter.thesis** (already on EnrichedChapter, sourced from spine YAML) through to `compose_chapter_prose` as `arc_thesis=`. ACT-003 added the parameter; the spine composer was never updated to pass it.
- **Populates `chapter_thesis` block** with 20 distinct sentences in the flagship F006 overwhelm arc (gen_z_professionals × anxiety). No two start the same; none use the legacy "The point is that..." opening.

## Why
Highest-leverage drift identified in `artifacts/analysis/peak_quality_reconstruction.md` (Disconnection 1). The composer's 4-stage derivation chain (`arc_thesis > chapter_thesis_bank > mechanism_thesis_families > legacy`) was never reaching stage 1 because the spine call site dropped chapter.thesis on the floor. Result: every recognition-role chapter rendered the same generic "The alarm fires on prediction, not evidence." sentence.

## Verification
End-to-end spine run:
```
python3 scripts/run_pipeline.py --topic anxiety --persona gen_z_professionals \
  --arc config/source_of_truth/master_arcs/gen_z_professionals__anxiety__overwhelm__F006.yaml \
  --pipeline-mode spine --runtime-format standard_book --no-job-check \
  --render-book --no-generate-freebies --no-update-freebie-index \
  --quality-profile draft --render-dir /tmp/p0_arc_thesis_test2/
```

| Check | Before | After |
|---|---|---|
| Ch 1 thesis in prose | "The alarm fires on prediction, not evidence." (generic) | "There is a part of you that is always scanning — and you've been so good at living inside that scan that you've mistaken it for just being the kind of person you are." (spine-authored) |
| Editorial thesis drift | (unmeasured baseline) | 0 / 12 chapters |
| chapter_flow gate | PASS (0/12 failed) | PASS (0/12 failed) |
| EI V2 composite | — | 0.64 |
| bestseller_craft ONTGP | — | 0.60 |

## Test plan
- [x] `tests/test_arc_loader.py` — 5/5 pass (chapter_thesis schema validation)
- [x] End-to-end spine run produces book.txt with the new thesis appearing in body + takeaway
- [x] All 12 spine integration tests still pass

## Out of scope
- Spine YAML thesis vs. arc YAML thesis as the canonical source — both flow now; future PR can prefer one. Today the spine is the source for the spine path; arc is for registry mode.
- Population of other arcs (false_alarm, shame, watcher, comparison, grief, spiral) — flagship F006 overwhelm is the test case the user actually generates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)